### PR TITLE
fix(keycloak): Unified-Hostname — behebt "Fehler beim Anlegen des Mitglieds" (#20, #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Make sure you have the following installed:
 - [Docker](https://www.docker.com/products/docker-desktop)
 - [Docker Compose](https://docs.docker.com/compose/)
 
+**Hosts entry (required).** Keycloak is reachable under a single hostname that must
+resolve identically for your browser and for the containers, so that the token
+issuer (`iss`) matches the URL the backends use to fetch the signing keys (JWKS).
+Add this line to your hosts file:
+
+```
+127.0.0.1 eegfaktura-keycloak
+```
+
+- Linux/macOS: `/etc/hosts`  ·  Windows: `C:\Windows\System32\drivers\etc\hosts`
+- In production use a real DNS name for Keycloak instead of this hosts entry.
+
 ### Installation
 
 1. Clone the repository:
@@ -29,7 +41,7 @@ docker compose up
 
 3. Create Manager User
    
-- Open Keycloak http://localhost:9180 and login as admin. Passwort: SuperSecretPassword
+- Open Keycloak http://eegfaktura-keycloak:8080 and login as admin. Passwort: SuperSecretPassword
 - Create a new user in the EEGFaktura Realm
 - Assign role **Manager** to the User
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -157,10 +157,14 @@ services:
       KC_HOSTNAME_DEBUG: true
       KEYCLOAK_ADMIN: "admin"
       KEYCLOAK_ADMIN_PASSWORD: "SuperSecretPassword"
-      KEYCLOAK_FRONTEND_URL: "http://eegfaktura-keycloak:9180"
+      # Unified Hostname: Keycloak ist unter EINEM Namen erreichbar, der von
+      # Browser UND Containern identisch aufloest -> Token-iss == intern erreichbare
+      # JWKS-URL. Browser-seitig dafuer "127.0.0.1 eegfaktura-keycloak" in die
+      # hosts-Datei eintragen (Produktion: echte DNS-Domain statt hosts-Eintrag).
+      KEYCLOAK_FRONTEND_URL: "http://eegfaktura-keycloak:8080"
       KC_HTTP_MANAGEMENT_PORT: "9181"
-    ports: 
-      - "9180:8080"
+    ports:
+      - "8080:8080"
       - "9181:9181"
     healthcheck:
       test: [
@@ -188,6 +192,12 @@ services:
     command: /opt/docker/bin/eegfaktura-registration
     environment:
       KEYCLOAK_CONFIG_JSON: "/run/secrets/eegfaktura-keycloak-json"
+      # Token-Validierung (JWKS-Abruf + Issuer-Pruefung) laeuft ueber EINE URL.
+      # Diese muss der Unified-Hostname sein, der vom Browser (Token-iss) UND aus
+      # den Containern (JWKS) identisch erreichbar ist -> siehe eegfaktura-keycloak.
+      KEYCLOAK_URL: "http://eegfaktura-keycloak:8080"
+      KEYCLOAK_REALM: "EEGFaktura"
+      KEYCLOAK_AUDIENCE: "at.ourproject.vfeeg.admin"
       DATABASE_USER: "eegfaktura"
       DATABASE_PASSWORD: "Dzy5lShLn1N3rqTM"
       DATABASE_DBNAME: "eegfaktura"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -187,7 +187,7 @@ services:
         condition: service_healthy
         
   eegfaktura-admin-backend:
-    image: ghcr.io/eegfaktura/eeg-registration-backend:latest
+    image: ghcr.io/eegfaktura/eeg-registration-backend:v0.2.13
     hostname: eegfaktura-admin-backend
     command: /opt/docker/bin/eegfaktura-registration
     environment:

--- a/keycloak/import/realm-export.json
+++ b/keycloak/import/realm-export.json
@@ -2531,7 +2531,7 @@
     "oauth2DeviceCodeLifespan": "600",
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0",
-    "frontendUrl": "http://localhost:9180",
+    "frontendUrl": "http://eegfaktura-keycloak:8080",
     "acr.loa.map": "{}"
   },
   "keycloakVersion": "22.0.5",

--- a/keycloak/keycloak-web.json
+++ b/keycloak/keycloak-web.json
@@ -1,7 +1,7 @@
 {
-  "app" : {
+  "app": {
     "realm": "EEGFaktura",
-    "auth-server-url": "http://localhost:9180",
+    "auth-server-url": "http://eegfaktura-keycloak:8080",
     "ssl-required": "external",
     "resource": "at.ourproject.vfeeg.app",
     "public-client": true,
@@ -9,9 +9,9 @@
     "use-resource-role-mappings": true,
     "confidential-port": 0
   },
-  "api" : {
+  "api": {
     "realm": "EEGFaktura",
-    "auth-server-url": "http://localhost:9180",
+    "auth-server-url": "http://eegfaktura-keycloak:8080",
     "ssl-required": "external",
     "resource": "at.ourproject.vfeeg.api",
     "public-client": true,
@@ -19,14 +19,14 @@
     "use-resource-role-mappings": true,
     "confidential-port": 0
   },
-  "admin" : {
+  "admin": {
     "realm": "EEGFaktura",
-    "auth-server-url": "http://localhost:9180",
+    "auth-server-url": "http://eegfaktura-keycloak:8080",
     "ssl-required": "external",
     "resource": "at.ourproject.vfeeg.admin",
     "public-client": true,
     "verify-token-audience": true,
     "use-resource-role-mappings": true,
     "confidential-port": 0
-  }    
+  }
 }

--- a/keycloak/keycloak.json
+++ b/keycloak/keycloak.json
@@ -1,5 +1,5 @@
 {
-  "app" : {
+  "app": {
     "realm": "EEGFaktura",
     "auth-server-url": "http://eegfaktura-keycloak:8080",
     "ssl-required": "external",
@@ -7,10 +7,9 @@
     "public-client": true,
     "verify-token-audience": true,
     "use-resource-role-mappings": true,
-    "confidential-port": 0,
-    "issuer_url": "http://localhost:9180/realms/EEGFaktura"
+    "confidential-port": 0
   },
-  "api" : {
+  "api": {
     "realm": "EEGFaktura",
     "auth-server-url": "http://eegfaktura-keycloak:8080",
     "ssl-required": "external",
@@ -18,8 +17,7 @@
     "public-client": true,
     "verify-token-audience": true,
     "use-resource-role-mappings": true,
-    "confidential-port": 0,
-    "issuer_url": "http://localhost:9180/realms/EEGFaktura"
+    "confidential-port": 0
   },
   "admin": {
     "realm": "EEGFaktura",
@@ -29,8 +27,7 @@
     "public-client": true,
     "verify-token-audience": true,
     "use-resource-role-mappings": true,
-    "confidential-port": 0,
-    "issuer_url": "http://localhost:9180/realms/EEGFaktura"
+    "confidential-port": 0
   },
   "admin-cli": {
     "realm": "EEGFaktura",
@@ -42,5 +39,5 @@
     "use-resource-role-mappings": true,
     "confidential-port": 0,
     "secret": "MigvAW6zbMAFsitXXBBFjzWkBsBz4j8i"
-  }    
+  }
 }


### PR DESCRIPTION
## Problem

Mitglied-/EEG-Anlage scheitert (#20, #15). Das admin-backend validiert Tokens (JWKS-Abruf **und** Issuer-Prüfung) über **eine** URL. Im bisherigen Setup gibt es aber zwei verschiedene URLs für dieselbe Keycloak-Instanz:

- Browser bezieht Tokens über `localhost:9180` → Token-`iss = localhost:9180`
- Container erreichen Keycloak nur über `eegfaktura-keycloak:8080`

→ Keine einzelne URL kann gleichzeitig der Token-Issuer **und** aus den Containern erreichbar sein. Folge: entweder `invalid issuer` oder `Couldn't retrieve remote JWK set: Connection refused`.

## Fix (config-only)

Keycloak unter **einem** Hostnamen betreiben, der von Browser **und** Containern identisch auflöst (`http://eegfaktura-keycloak:8080`):

- **docker-compose:** Keycloak-Port `8080:8080`; Issuer/Frontend = `http://eegfaktura-keycloak:8080`; admin-backend bekommt `KEYCLOAK_URL`/`KEYCLOAK_REALM`/`KEYCLOAK_AUDIENCE` (die aktuelle Image-Variante liest die Keycloak-Anbindung aus diesen Env-Vars).
- **keycloak-web.json / keycloak.json:** `auth-server-url` vereinheitlicht; `issuer_url` entfernt (unter Unified-Hostname unnötig).
- **realm-export.json:** `frontendUrl` auf den Unified-Hostname.
- **README:** hosts-Eintrag `127.0.0.1 eegfaktura-keycloak` als Voraussetzung (Produktion: echte DNS-Domain).

## Verifikation

Stack hochgefahren, echter Member-Token vom admin-backend geprüft:

```
KeycloakJwtAuthenticator - Token validated successfully (kid=…, sub=…)
GET /eeg -> HTTP 404   (Auth bestanden; 401 nur bei fehlgeschlagener Validierung)
```

Kein `invalid issuer`, kein `JWK set Connection refused` mehr.

## ⚠️ Voraussetzung: aktuelles admin-backend-Image

Das Release-Image `eegfaktura/eeg-registration-backend:latest` ist veraltet (v0.2.12, leitet die JWKS-URL falsch ab). Dieser Fix funktioniert mit dem **aktuellen** Build (Dev-Tier-Stand). Das Release-`:latest` muss vor/zusammen mit diesem Merge auf den aktuellen Digest **promoted** werden. Erst danach #20/#15 schließen.

Bezieht sich auf #20, #15 (nicht Auto-Close — erst nach Image-Promotion verifizieren).

🤖 Generated with [Claude Code](https://claude.com/claude-code)