### PR TITLE
fix(eda-xp): persistence-Pfad unter pekko{} statt totem akka{}-Block

### DIFF
--- a/eegfaktura-eda.application.conf
+++ b/eegfaktura-eda.application.conf
@@ -110,28 +110,13 @@ logger.scala.slick.jdbc.JdbcBackend.statement=INFO
 logging.level.com.zaxxer.hikari.HikariConfig=INFO
 logging.level.com.zaxxer.hikari=INFO
 
-akka {
-  logger.scala.slick = "INFO"
-  loglevel = "DEBUG"
-  stdout-loglevel = "DEBUG"
-  actor.debug.lifecycle = off
-  loggers = ["akka.event.slf4j.Slf4jLogger"]
-
-  persistence.journal.plugin = "akka.persistence.journal.leveldb"
-  persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
-
+# Persistence-Plugin/Serializer/http2/Logging kommen aus dem gebackenen reference.conf
+# (pekko-Namespace). Hier wird NUR der Journal-/Snapshot-Pfad auf das absolute PVC
+# /storage/prod überschrieben — reference.conf nutzt einen relativen Default, der im
+# Container-Workdir /opt/docker nicht schreibbar ist.
+# (Stand früher fälschlich unter akka{} → von Pekko ignoriert → env-Persistence lief
+#  nie; auf pekko{} korrigiert 2026-07-12. Prod setzte denselben Pfad schon korrekt.)
+pekko {
   persistence.journal.leveldb.dir = "/storage/prod/journal"
   persistence.snapshot-store.local.dir = "/storage/prod/snapshots"
-
-  akka.persistence.journal.leveldb.native = false
-
-  http.server.enable-http2 = on
-#  http.server.preview.enable-http2 = on
-#  http2.enable = true
-
-  actor {
-    serialization-bindings {
-      "at.energydash.actors.CborSerializable" = jackson-cbor
-    }
-  }
 }


### PR DESCRIPTION
Journal-/Snapshot-Pfad stand unter totem `akka{}`-Block (falscher Namespace seit Akka→Pekko-Migration → von Pekko ignoriert). eda-xp fiel auf den relativen reference.conf-Default zurück, der im Container-Workdir /opt/docker nicht schreibbar ist → Persistence-Actor scheiterte (leveldb LOCK), non-fatal aber Persistence lief nie. Fix: minimaler `pekko{}`-Block mit absolutem PVC-Pfad /storage/prod (Rest kommt aus reference.conf). Verifiziert in env-billing: LOCK-Fehler weg, leveldb legt journal/snapshots auf dem PVC an, Pod 1/1 Ready. Prod war korrekt (pekko{}), env/lokal betroffen. Entdeckt beim ADR-0011-Audit.